### PR TITLE
fix: Ensure dashboards persist and filters sync correctly

### DIFF
--- a/src/Dashboards.tsx
+++ b/src/Dashboards.tsx
@@ -31,6 +31,11 @@ const EmbeddedDashboard: React.FC<EmbeddedDashboardProps> = ({ id, isActive }) =
     const { dashboardFilters, setDashboardFilters: setSharedFilters } = useContext(DashboardFilterContext);
     const embedCtrRef = useRef<HTMLDivElement | null>(null);
     const [localDashboard, setLocalDashboard] = useState<LookerEmbedDashboard | null>(null);
+    const isActiveRef = useRef(isActive);
+
+    useEffect(() => {
+        isActiveRef.current = isActive;
+    }, [isActive]);
 
     useEffect(() => {
         // Ensure id is present; though as a prop, it should always be.
@@ -38,7 +43,9 @@ const EmbeddedDashboard: React.FC<EmbeddedDashboardProps> = ({ id, isActive }) =
             let dashboardBuilder = LookerEmbedSDK.createDashboardWithId(id)
                 .appendTo(embedCtrRef.current)
                 .on('dashboard:filters:changed', (event) => {
-                    setSharedFilters(event.dashboard.dashboard_filters);
+                    if (isActiveRef.current) { // Only update context if this tab is active
+                        setSharedFilters(event.dashboard.dashboard_filters);
+                    }
                 });
 
             // Apply filters from context if they exist and are not empty
@@ -86,14 +93,14 @@ export default EmbeddedDashboard;
 // Styled container for the embedded dashboard
 export const EmbedContainer = styled.div<{ isActive?: boolean }>`
   width: 100%;
-  height: 95vh;
-  opacity: ${({ isActive }) => (isActive ? 1 : 0)};
-  transition: opacity 0.5s ease-in-out;
-  pointer-events: ${({ isActive }) => (isActive ? 'auto' : 'none')}; /* Prevent interaction with hidden dashboards */
-
+  height: 100%; /* Changed from 95vh to fill TabPanel better */
+  display: ${props => props.isActive ? 'flex' : 'none'}; /* Use flex to allow iframe to fill */
+  flex-direction: column; /* Ensure iframe content flows correctly */
+  
   & > iframe {
+    flex-grow: 1; /* Allow iframe to take available space */
+    border: none; /* Remove default iframe border */
     width: 100%;
     height: 100%;
-    border: none; /* Remove default iframe border */
   }
 `;

--- a/src/Tabs.tsx
+++ b/src/Tabs.tsx
@@ -102,13 +102,10 @@ export const TabbedDashboards = () => {
                                 // MUI TabPanel uses 'hidden' attribute for inactive panels, no need for manual visibility
                             }}
                         >
-                            {/* Render EmbeddedDashboard only when its tab is active to avoid loading all dashboards at once */}
-                            {activeTabValue === String(index) && (
-                                <EmbeddedDashboard
-                                    id={tab.id}
-                                    isActive={true} // isActive is always true when rendered due to the condition above
-                                />
-                            )}
+                            <EmbeddedDashboard
+                                id={tab.id}
+                                isActive={activeTabValue === String(index)} // Correctly pass active state
+                            />
                         </TabPanel>
                     ))}
                 </TabContext>


### PR DESCRIPTION
This commit addresses two issues:
1. Dashboards were reloading from scratch when switching tabs.
2. Filter synchronization was not consistently maintained across tab switches.

Changes Made:

1.  **Persistent Dashboard Rendering (`src/Tabs.tsx`):**
    - Modified `Tabs.tsx` to remove conditional rendering of `EmbeddedDashboard` instances. All dashboards are now rendered persistently.
    - The `isActive` prop is still passed to each `EmbeddedDashboard` to indicate its current active state.

2.  **Visibility Control (`src/Dashboards.tsx`):**
    - The `EmbedContainer` in `EmbeddedDashboard.tsx` now uses the `isActive` prop to set its `display` CSS property (e.g., `flex` for active, `none` for inactive). This keeps dashboard instances mounted but hidden, preserving their state and preventing reloads.

3.  **Refined Filter Logic (`src/Dashboards.tsx`):**
    - The `on('dashboard:filters:changed')` event handler within `EmbeddedDashboard` now checks if the dashboard is currently active (using `isActiveRef.current`) before updating the shared `DashboardFilterContext`. This prevents inactive dashboards from overwriting shared filters.
    - The `useEffect` hook responsible for applying shared filters to the local Looker dashboard instance continues to ensure that an active dashboard reflects the latest context filters.
    - The initial dashboard creation still attempts to apply existing shared filters using `.withFilters()` for its first-time load.

These changes ensure that dashboards are not reloaded when switching tabs, their states are preserved, and filter synchronization is robust and consistent across all dashboards.